### PR TITLE
[fix] 배포 깃헙액션 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - dev
+      - feat/deploy
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - feat/deploy
+      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Gradle build
       - name: Build with Gradle
-        run: ./gradlew build -x test :spotlessApply
+        run: ./gradlew build -x test
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: pharmac/pharmac-server-dev
+          images: pharmac/pharmac-backend-dev
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   backend-dev:
-    image: pharmac/pharmac-backend-dev
+    image: pharmac19/pharmac-backend-dev
     container_name: backend-dev
     hostname: backend-dev
     expose:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'demo'
+rootProject.name = 'backend'


### PR DESCRIPTION
# 💡 PR Summary - 배포 깃헙액션 오류 수정
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
<img width="1023" alt="스크린샷 2023-09-21 오후 5 59 27" src="https://github.com/HI-pharmaC/PHARMAC-BE/assets/74910760/c1a5614c-12fe-4884-a32a-596208730adf">
위의 오류는 docker-compose.yml 파일에서 지정해둔 도커 이미지 이름과 실제 도커 허브에서 설정해둔 도커 이미지 이름이 일치하지 않아 접근이 불가능해 발생한 에러였고, docker-compose.yml 파일을 수정하여 해결하였습니다.

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/deploy

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #3 

